### PR TITLE
Add packaging configuration for advanced_precision

### DIFF
--- a/advanced_precision/__init__.py
+++ b/advanced_precision/__init__.py
@@ -1,0 +1,5 @@
+"""Advanced Precision package."""
+
+__all__ = []
+
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = advanced-precision
+version = 0.1.0
+description = AdvancedPrecision package
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = AdvancedPrecision Team
+
+[options]
+packages = find:
+python_requires = >=3.8
+zip_safe = False
+
+[options.packages.find]
+include = advanced_precision

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
## Summary
- add a minimal `advanced_precision` package with version metadata
- configure setuptools via `pyproject.toml`, `setup.cfg`, and a stub `setup.py` for editable installs

## Testing
- `pip install -e .` *(fails in this environment: cannot download build dependency `setuptools` due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d71236f3848322ad6480e874a8722c